### PR TITLE
Enable the x-axis time to be either the beginning (start) or end (stop) of the interval

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
             {
             "name": "weectl report",
-            "type": "debugpy",
+            "type": "python",
             "request": "launch",
             "justMyCode": false,
             "program": "~/weewx/src/weectl.py",

--- a/bin/user/jas.py
+++ b/bin/user/jas.py
@@ -2036,6 +2036,9 @@ class DataGenerator(JASGenerator):
         report_dict = self.config_dict.get('StdReport', {})
         self.unit_system = self.skin_dict.get('unit_system', 'us').upper()
 
+        self.time_display = self.skin_dict['Extras'].get('time_display', 'stop').lower()
+        self.aggregate_time_display = self.skin_dict['Extras'].get('aggregate_time_display', 'stop').lower()
+
         now = time.time()
         self.utc_offset = (datetime.datetime.fromtimestamp(now) -
                            datetime.datetime.utcfromtimestamp(now)).total_seconds()/60
@@ -2609,7 +2612,7 @@ class DataGenerator(JASGenerator):
                         array_name = name_prefix
 
                         if aggregate_interval is not None:
-                            data += "  pageData." + array_name + " = " + self._get_series(observation, data_binding, interval, aggregate_type, aggregate_interval, 'stop', 'unix_epoch_ms', unit_name, 2, True) + ";\n"
+                            data += "  pageData." + array_name + " = " + self._get_series(observation, data_binding, interval, aggregate_type, aggregate_interval, self.aggregate_time_display, 'unix_epoch_ms', unit_name, 2, True) + ";\n"
                         else:
                             # wind 'observation' is special see #87
                             if observation == 'wind':
@@ -2621,7 +2624,7 @@ class DataGenerator(JASGenerator):
                             else:
                                 weewx_observation = observation
                             #end if
-                            data += "  pageData." + array_name + " = " + self._get_series(weewx_observation, data_binding, interval, None, None, 'stop', 'unix_epoch_ms', unit_name, 2, True) + ";\n"
+                            data += "  pageData." + array_name + " = " + self._get_series(weewx_observation, data_binding, interval, None, None, self.time_display, 'unix_epoch_ms', unit_name, 2, True) + ";\n"
 
         data += "\n"
         return data

--- a/bin/user/jas.py
+++ b/bin/user/jas.py
@@ -178,7 +178,7 @@ except ImportError:
         logmsg(syslog.LOG_ERR, msg)
 
 
-VERSION = "1.2.0-rc02"
+VERSION = "1.2.0-rc03"
 
 class JAS(SearchList):
     """ Implement tags used by templates in the skin. """

--- a/install.py
+++ b/install.py
@@ -12,7 +12,7 @@ except ImportError:
 import configobj
 from weecfg.extension import ExtensionInstaller
 
-VERSION = "1.2.0-rc02"
+VERSION = "1.2.0-rc03"
 
 EXTENSION_CONFIG = """
 [StdReport]

--- a/skins/jas/skin.conf
+++ b/skins/jas/skin.conf
@@ -2,7 +2,8 @@
 #    See the file LICENSE.txt for your rights.
 
 SKIN_NAME = Jas
-SKIN_VERSION = 1.2.0-rc02
+# quotes make it consistent with search in python files
+SKIN_VERSION = "1.2.0-rc03"
 
 [Extras]
     #debug = True

--- a/skins/jas/skin.conf
+++ b/skins/jas/skin.conf
@@ -2,7 +2,7 @@
 #    See the file LICENSE.txt for your rights.
 
 SKIN_NAME = Jas
-SKIN_VERSION = 1.1.0-rc01
+SKIN_VERSION = 1.2.0-rc02
 
 [Extras]
     #debug = True


### PR DESCRIPTION
The time displayed can either be the beginning (start) or end (stop) of the interval. This can be set differently for aggregates and non-aggregates.
Setting it to stop for aggregates fixes #145.
WeeWX uses the end (stop). This results in the first value displayed for day aggregation to be the ‘second’ (for example 02 of the month). For this reason and to fix #145, I like to have aggregate set to start. But for consistency with WeeWX set the non-aggregates to stop.
The default for both is stop.